### PR TITLE
Sbtc incentives

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -102,6 +102,7 @@ The assistant has access to various tools for performing blockchain operations:
 - Get the STX supply (total and unlocked) (using **get_stx_supply**)
 - Get the available pools in [Velar](https://velar.com/) (using **get_pool_information_velar**)
 - Get the available tokens to use in [Velar](https://velar.com/) (using **get_token_information_velar**)
+- Get the status of the enrollment in [sBTC Incentives](https://bitcoinismore.org/) for a wallet (using **get_sbtc_enrollment**)
 
 
 #### Write Operations

--- a/Readme.md
+++ b/Readme.md
@@ -103,6 +103,10 @@ The assistant has access to various tools for performing blockchain operations:
 - Get the available pools in [Velar](https://velar.com/) (using **get_pool_information_velar**)
 - Get the available tokens to use in [Velar](https://velar.com/) (using **get_token_information_velar**)
 - Get the status of the enrollment in [sBTC Incentives](https://bitcoinismore.org/) for a wallet (using **get_sbtc_enrollment**)
+- Get the status of the enrollment in sBTC Incentives for a wallet (if no address is specified, use the current wallet) (using **get_sbtc_enrollment**)
+- Get the current cycle for sBTC rewards (using **get_sbtc_currentcycle**)
+- Get the current/last sBTC reward address for a specific address (using **get_sbtc_rewardaddress**)
+- Get the sBTC rewards for a specific cycle and address (using **get_sbtc_rewardsbycycleaddress**)
 
 
 #### Write Operations
@@ -110,6 +114,9 @@ The assistant has access to various tools for performing blockchain operations:
   - Transaction value in STX or any token
   - The token to send (stx, sbtc, etc.). If no token is specified, use the default (STX).*
   - Address.
+- Enroll for sBTC incentives (using the agent wallet) and get rewards (using **enroll_sbtc_incentives**)
+- Change the address to receive the sBTC rewards (using **change_sbtc_rewardaddress**)
+- Unenroll/opt-out for sBTC incentives (using **optout_sbtc_incentives**)
 
 *The agent will use the default token or currency if none is specified in the transaction, or if a query has previously been made about a specific token (e.g. _sBTC_), it will use that one in subsequent queries until another is specified.
 

--- a/interface/index.ts
+++ b/interface/index.ts
@@ -78,3 +78,17 @@ export interface GetPoolInformationArgs {
    */
   wallet: string;
 }
+
+/**
+ * Arguments for the get_sbtc_rewardaddress tool
+ */
+ export interface GetsBTCRewardsByCycleAddressArgs {
+  /**
+   * The cycle to get the rewards of
+   */
+   cycle: number;
+  /**
+   * The wallet to get the rewards of
+   */
+  wallet: string;
+}

--- a/interface/index.ts
+++ b/interface/index.ts
@@ -49,3 +49,15 @@ export interface GetPoolInformationArgs {
   token0?: string;
   token1?: string;
 }
+
+// sBTC
+
+/**
+ * Arguments for the get_sbtc_enrollment tool
+ */
+ export interface GetsBTCEnrollmentArgs {
+  /**
+   * The wallet to get the balance of
+   */
+  wallet: string;
+}

--- a/interface/index.ts
+++ b/interface/index.ts
@@ -68,3 +68,13 @@ export interface GetPoolInformationArgs {
  export interface GetsBTCCurrentCycleArgs {
 
 }
+
+/**
+ * Arguments for the get_sbtc_rewardaddress tool
+ */
+ export interface GetsBTCRewardAddressArgs {
+  /**
+   * The wallet to get the reward address of
+   */
+  wallet: string;
+}

--- a/interface/index.ts
+++ b/interface/index.ts
@@ -61,3 +61,10 @@ export interface GetPoolInformationArgs {
    */
   wallet: string;
 }
+
+/**
+ * Arguments for the get_sbtc_currentcycle tool
+ */
+ export interface GetsBTCCurrentCycleArgs {
+
+}

--- a/src/constants/prompt.ts
+++ b/src/constants/prompt.ts
@@ -29,6 +29,7 @@ WRITE OPERATIONS:
 - Send coins and tokens using send_transaction
 - Enroll for sBTC incentives and get rewards using enroll_sbtc_incentives
 - Change the address to receive the sBTC incentives using change_sbtc_rewardaddress
+- Unenroll/opt-out for sBTC incentives using optout_sbtc_incentives
 
 When executing operations:
 1. ALWAYS use reasonable defaults when specific values aren't provided:

--- a/src/constants/prompt.ts
+++ b/src/constants/prompt.ts
@@ -20,6 +20,7 @@ READ OPERATIONS:
 - Get the STX supply (total and unlocked) using get_stx_supply
 - Get information (name, symbol, prices, contract address, and website) about tokens available in Velar Protocol using get_token_information_velar
 - Get information (tokens and total value locked in USD) about pool available in Velar Protocol using get_pool_information_velar
+- Get the status of the enrollment in sBTC Incentives for a wallet (if no wallet is specified, use the current address) using get_sbtc_enrollment
 
 WRITE OPERATIONS:
 - Send coins and tokens using send_transaction
@@ -28,6 +29,7 @@ When executing operations:
 1. ALWAYS use reasonable defaults when specific values aren't provided:
    - For transactions, use standard gas parameters unless specified
    - For token operations, maintain context of deployed addresses
+   - For actions when an address is requested, use the current wallet (in get_wallet_address) is none is specified.
 
 2. ALWAYS maintain and include critical information:
    - Save and reference contract addresses from deployments

--- a/src/constants/prompt.ts
+++ b/src/constants/prompt.ts
@@ -21,6 +21,7 @@ READ OPERATIONS:
 - Get information (name, symbol, prices, contract address, and website) about tokens available in Velar Protocol using get_token_information_velar
 - Get information (tokens and total value locked in USD) about pool available in Velar Protocol using get_pool_information_velar
 - Get the status of the enrollment in sBTC Incentives for a wallet (if no wallet is specified, use the current address) using get_sbtc_enrollment
+- Get the current cycle for sBTC rewards using get_sbtc_currentcycle
 
 WRITE OPERATIONS:
 - Send coins and tokens using send_transaction

--- a/src/constants/prompt.ts
+++ b/src/constants/prompt.ts
@@ -22,7 +22,8 @@ READ OPERATIONS:
 - Get information (tokens and total value locked in USD) about pool available in Velar Protocol using get_pool_information_velar
 - Get the status of the enrollment in sBTC Incentives for a wallet (if no wallet is specified, use the current address) using get_sbtc_enrollment
 - Get the current cycle for sBTC rewards using get_sbtc_currentcycle
-- Get the current/last sBTC reward address for a specific address using get_sbtc_currentcycle
+- Get the current/last sBTC reward address for a specific address using get_sbtc_rewardaddress
+- Get the sBTC rewards for a specific cycle and address using get_sbtc_rewardsbycycleaddress
 
 WRITE OPERATIONS:
 - Send coins and tokens using send_transaction

--- a/src/constants/prompt.ts
+++ b/src/constants/prompt.ts
@@ -27,6 +27,7 @@ READ OPERATIONS:
 
 WRITE OPERATIONS:
 - Send coins and tokens using send_transaction
+- Enroll for sBTC incentives and get rewards using enroll_sbtc_incentives
 
 When executing operations:
 1. ALWAYS use reasonable defaults when specific values aren't provided:

--- a/src/constants/prompt.ts
+++ b/src/constants/prompt.ts
@@ -22,6 +22,7 @@ READ OPERATIONS:
 - Get information (tokens and total value locked in USD) about pool available in Velar Protocol using get_pool_information_velar
 - Get the status of the enrollment in sBTC Incentives for a wallet (if no wallet is specified, use the current address) using get_sbtc_enrollment
 - Get the current cycle for sBTC rewards using get_sbtc_currentcycle
+- Get the current/last sBTC reward address for a specific address using get_sbtc_currentcycle
 
 WRITE OPERATIONS:
 - Send coins and tokens using send_transaction

--- a/src/constants/prompt.ts
+++ b/src/constants/prompt.ts
@@ -28,6 +28,7 @@ READ OPERATIONS:
 WRITE OPERATIONS:
 - Send coins and tokens using send_transaction
 - Enroll for sBTC incentives and get rewards using enroll_sbtc_incentives
+- Change the address to receive the sBTC incentives using change_sbtc_rewardaddress
 
 When executing operations:
 1. ALWAYS use reasonable defaults when specific values aren't provided:

--- a/src/constants/stackseco.ts
+++ b/src/constants/stackseco.ts
@@ -1,1 +1,4 @@
 export const VELAR_BASE_URL:string = "https://api.velar.co";
+
+export const sBTC_CONTRACT_ADDRESS : string = "SP804CDG3KBN9M6E00AD744K8DC697G7HBCG520Q";
+export const sBTC_CONTRACT_NAME : string = "sbtc-yield-rewards-v3";

--- a/src/sbtc/yieldActions.ts
+++ b/src/sbtc/yieldActions.ts
@@ -88,8 +88,6 @@ export async function getRewardsByCycleAddress(cycle:number,address:string) {
         network:"mainnet"
       });
 
-    console.log(rewardsResult);
-
     const rewards = Number(rewardsResult.value.value) / 10**8;
 
 
@@ -160,4 +158,35 @@ export async function changeRewardAddress(newAddress:string) {
 
     const tx_result = await broadcastTransaction({ transaction, network:"mainnet" });
     return `The reward address was changed, and the transaction id ${tx_result.txid}`;
+}
+
+export async function optoutToIncentives() {
+
+    if (!process.env.WALLET_MNEMONIC) {
+        throw new Error(
+        "WALLET_MNEMONIC environment variable is not set. You need to set it to create a wallet client."
+        );
+    }
+    // Create a wallet from the mnemonic
+    const wallet = await generateWallet({
+        secretKey: process.env.WALLET_MNEMONIC,
+        password: '',
+    });
+
+
+    const transaction = await makeContractCall({
+        contractName: sBTC_CONTRACT_NAME,
+        contractAddress: sBTC_CONTRACT_ADDRESS,
+        functionName: "opt-out",
+        functionArgs:[],
+        senderKey: wallet.accounts[0].stxPrivateKey,
+        validateWithAbi: true,
+        network: "mainnet",
+        postConditions: [],
+        //postConditionMode: PostConditionMode.Deny,
+      });
+    
+
+    const tx_result = await broadcastTransaction({ transaction, network:"mainnet" });
+    return `The unenrollment/opt-out for sBTC Incentives was successfully, with transaction id ${tx_result.txid}`;
 }

--- a/src/sbtc/yieldActions.ts
+++ b/src/sbtc/yieldActions.ts
@@ -129,3 +129,35 @@ export async function enrollToIncentives() {
     const tx_result = await broadcastTransaction({ transaction, network:"mainnet" });
     return `The enrollment for sBTC Incentives was successfully, with transaction id ${tx_result.txid}`;
 }
+
+export async function changeRewardAddress(newAddress:string) {
+
+    if (!process.env.WALLET_MNEMONIC) {
+        throw new Error(
+        "WALLET_MNEMONIC environment variable is not set. You need to set it to create a wallet client."
+        );
+    }
+    // Create a wallet from the mnemonic
+    const wallet = await generateWallet({
+        secretKey: process.env.WALLET_MNEMONIC,
+        password: '',
+    });
+
+
+    const transaction = await makeContractCall({
+        contractName: sBTC_CONTRACT_NAME,
+        contractAddress: sBTC_CONTRACT_ADDRESS,
+        functionName: "change-reward-address",
+        functionArgs:[
+            Cl.principal(newAddress)],
+        senderKey: wallet.accounts[0].stxPrivateKey,
+        validateWithAbi: true,
+        network: "mainnet",
+        postConditions: [],
+        //postConditionMode: PostConditionMode.Deny,
+      });
+    
+
+    const tx_result = await broadcastTransaction({ transaction, network:"mainnet" });
+    return `The reward address was changed, and the transaction id ${tx_result.txid}`;
+}

--- a/src/sbtc/yieldActions.ts
+++ b/src/sbtc/yieldActions.ts
@@ -1,11 +1,13 @@
-import { fetchCallReadOnlyFunction, Cl } from '@stacks/transactions';
+import { fetchCallReadOnlyFunction, Cl, privateKeyToAddress } from '@stacks/transactions';
+import { sBTC_CONTRACT_ADDRESS, sBTC_CONTRACT_NAME } from "../constants/stackseco";
+import { generateWallet } from "@stacks/wallet-sdk";
 
 
 export async function isWalletEnrolled(address:string) {
 
     const isCurrentEnrolledResult = await fetchCallReadOnlyFunction({
-        contractName: "sbtc-yield-rewards-v3",
-        contractAddress: "SP804CDG3KBN9M6E00AD744K8DC697G7HBCG520Q",
+        contractName: sBTC_CONTRACT_NAME,
+        contractAddress: sBTC_CONTRACT_ADDRESS,
         functionName: "is-enrolled-this-cycle",
         functionArgs:[Cl.principal(address)],
         senderAddress:address,
@@ -15,8 +17,8 @@ export async function isWalletEnrolled(address:string) {
     const isCurrentEnrolled = isCurrentEnrolledResult.type;
 
     const isNextCycleEnrolledResult = await fetchCallReadOnlyFunction({
-        contractName: "sbtc-yield-rewards-v3",
-        contractAddress: "SP804CDG3KBN9M6E00AD744K8DC697G7HBCG520Q",
+        contractName: sBTC_CONTRACT_NAME,
+        contractAddress: sBTC_CONTRACT_ADDRESS,
         functionName: "is-enrolled-in-next-cycle",
         functionArgs:[Cl.principal(address)],
         senderAddress:address,
@@ -27,5 +29,33 @@ export async function isWalletEnrolled(address:string) {
 
 
     return `The wallet is enrolled for this cycle?: ${isCurrentEnrolled}, is enrolled for the next cycle? ${isNextCycleEnrolled}`;
+    
+}
+
+export async function getCurrentCycle() {
+
+    if (!process.env.WALLET_MNEMONIC) {
+        throw new Error(
+        "WALLET_MNEMONIC environment variable is not set. You need to set it to create a wallet client."
+        );
+    }
+    // Create a wallet from the mnemonic
+    const wallet = await generateWallet({
+        secretKey: process.env.WALLET_MNEMONIC,
+        password: '',
+    });
+    const address = privateKeyToAddress(wallet.accounts[0].stxPrivateKey, 'mainnet');
+
+    const currentCycle = await fetchCallReadOnlyFunction({
+        contractName: sBTC_CONTRACT_NAME,
+        contractAddress: sBTC_CONTRACT_ADDRESS,
+        functionName: "current-cycle-id",
+        functionArgs:[],
+        senderAddress:address,
+        network:"mainnet"
+      });
+
+
+    return `The current cycle Id for sBTC Rewards: ${currentCycle.value}`;
     
 }

--- a/src/sbtc/yieldActions.ts
+++ b/src/sbtc/yieldActions.ts
@@ -1,0 +1,31 @@
+import { fetchCallReadOnlyFunction, Cl } from '@stacks/transactions';
+
+
+export async function isWalletEnrolled(address:string) {
+
+    const isCurrentEnrolledResult = await fetchCallReadOnlyFunction({
+        contractName: "sbtc-yield-rewards-v3",
+        contractAddress: "SP804CDG3KBN9M6E00AD744K8DC697G7HBCG520Q",
+        functionName: "is-enrolled-this-cycle",
+        functionArgs:[Cl.principal(address)],
+        senderAddress:address,
+        network:"mainnet"
+      });
+
+    const isCurrentEnrolled = isCurrentEnrolledResult.type;
+
+    const isNextCycleEnrolledResult = await fetchCallReadOnlyFunction({
+        contractName: "sbtc-yield-rewards-v3",
+        contractAddress: "SP804CDG3KBN9M6E00AD744K8DC697G7HBCG520Q",
+        functionName: "is-enrolled-in-next-cycle",
+        functionArgs:[Cl.principal(address)],
+        senderAddress:address,
+        network:"mainnet"
+      });
+
+    const isNextCycleEnrolled = isNextCycleEnrolledResult.type;
+
+
+    return `The wallet is enrolled for this cycle?: ${isCurrentEnrolled}, is enrolled for the next cycle? ${isNextCycleEnrolled}`;
+    
+}

--- a/src/sbtc/yieldActions.ts
+++ b/src/sbtc/yieldActions.ts
@@ -76,3 +76,23 @@ export async function getRewardAddress(address:string) {
 
     return `The reward address in sBTC incentives for ${rewardAddress} is ${rewardAddress}`;
 }
+
+export async function getRewardsByCycleAddress(cycle:number,address:string) {
+
+    const rewardsResult = await fetchCallReadOnlyFunction({
+        contractName: sBTC_CONTRACT_NAME,
+        contractAddress: sBTC_CONTRACT_ADDRESS,
+        functionName: "reward-amount-for-cycle-and-address",
+        functionArgs:[Cl.uint(cycle),Cl.principal(address)],
+        senderAddress:address,
+        network:"mainnet"
+      });
+
+    console.log(rewardsResult);
+
+    const rewards = Number(rewardsResult.value.value) / 10**8;
+
+
+
+    return `The rewards in sBTC incentives for ${cycle} cycle is ${rewards}`;
+}

--- a/src/sbtc/yieldActions.ts
+++ b/src/sbtc/yieldActions.ts
@@ -29,7 +29,6 @@ export async function isWalletEnrolled(address:string) {
 
 
     return `The wallet is enrolled for this cycle?: ${isCurrentEnrolled}, is enrolled for the next cycle? ${isNextCycleEnrolled}`;
-    
 }
 
 export async function getCurrentCycle() {
@@ -58,4 +57,22 @@ export async function getCurrentCycle() {
 
     return `The current cycle Id for sBTC Rewards: ${currentCycle.value}`;
     
+}
+
+export async function getRewardAddress(address:string) {
+
+    const rewardAddressResult = await fetchCallReadOnlyFunction({
+        contractName: sBTC_CONTRACT_NAME,
+        contractAddress: sBTC_CONTRACT_ADDRESS,
+        functionName: "get-latest-reward-address",
+        functionArgs:[Cl.principal(address)],
+        senderAddress:address,
+        network:"mainnet"
+      });
+
+    const rewardAddress = rewardAddressResult.value.value;
+
+
+
+    return `The reward address in sBTC incentives for ${rewardAddress} is ${rewardAddress}`;
 }

--- a/tools/allTools.ts
+++ b/tools/allTools.ts
@@ -11,6 +11,7 @@ import { getPoolInformationVelarTool } from "./getPoolInformationFromVelar";
 import { getsBTCEnrollmentTool } from "./getsBTCEnrollment";
 import { getsBTCCurrentCycleTool } from "./getsBTCCurrentCycle";
 import { getsBTCRewardAddressTool } from "./getsBTCRewardAddress";
+import { getsBTCRewardsByCycleAddressTool } from "./getsBTCRewardsByCycleAddress";
 
 export interface ToolConfig<T = any> {
   /**
@@ -88,6 +89,10 @@ export const tools: Record<string, ToolConfig> = {
    * Get the current reward address for sBTC incentives
    */
    get_sbtc_rewardaddress: getsBTCRewardAddressTool,
+  /**
+   * Get the rewards for an address for sBTC incentives
+   */
+   get_sbtc_rewardsbycycleaddress: getsBTCRewardsByCycleAddressTool,
 
   
   /**

--- a/tools/allTools.ts
+++ b/tools/allTools.ts
@@ -8,6 +8,7 @@ import { getSTXSupplyTool } from "./getSTXSupply";
 import { sendTransactionTool } from "./sendTransaction";
 import { getTokenInformationVelarTool } from "./getTokenInformation";
 import { getPoolInformationVelarTool } from "./getPoolInformationFromVelar";
+import { getsBTCEnrollmentTool } from "./getsBTCEnrollment";
 
 export interface ToolConfig<T = any> {
   /**
@@ -72,6 +73,11 @@ export const tools: Record<string, ToolConfig> = {
    * Get information about the tokens available in Velar protocol
    */
   get_pool_information_velar: getPoolInformationVelarTool,
+
+  /**
+   * Get the confirmation if a wallet is enrolled in sBTC incentives
+   */
+   get_sbtc_enrollment: getsBTCEnrollmentTool,
 
   
   /**

--- a/tools/allTools.ts
+++ b/tools/allTools.ts
@@ -14,6 +14,7 @@ import { getsBTCRewardAddressTool } from "./getsBTCRewardAddress";
 import { getsBTCRewardsByCycleAddressTool } from "./getsBTCRewardsByCycleAddress";
 import { enrollsBTCIncentivesTool } from "./enrollsBTCIncentives";
 import { changesBTCRewardAddressTool } from "./changesBTCRewardAddress";
+import { optoutsBTCIncentivesTool } from "./optOutBTCIncentives";
 
 export interface ToolConfig<T = any> {
   /**
@@ -110,4 +111,8 @@ export const tools: Record<string, ToolConfig> = {
    * Change the reward address for sBTC incentives
    */
    change_sbtc_rewardaddress: changesBTCRewardAddressTool,
+  /**
+   * Unenroll to sBTC incentives
+   */
+   optout_sbtc_incentives: optoutsBTCIncentivesTool,
 };

--- a/tools/allTools.ts
+++ b/tools/allTools.ts
@@ -10,6 +10,7 @@ import { getTokenInformationVelarTool } from "./getTokenInformation";
 import { getPoolInformationVelarTool } from "./getPoolInformationFromVelar";
 import { getsBTCEnrollmentTool } from "./getsBTCEnrollment";
 import { getsBTCCurrentCycleTool } from "./getsBTCCurrentCycle";
+import { getsBTCRewardAddressTool } from "./getsBTCRewardAddress";
 
 export interface ToolConfig<T = any> {
   /**
@@ -83,6 +84,10 @@ export const tools: Record<string, ToolConfig> = {
    * Get the current cycle for sBTC incentives
    */
    get_sbtc_currentcycle: getsBTCCurrentCycleTool,
+  /**
+   * Get the current reward address for sBTC incentives
+   */
+   get_sbtc_rewardaddress: getsBTCRewardAddressTool,
 
   
   /**

--- a/tools/allTools.ts
+++ b/tools/allTools.ts
@@ -12,6 +12,7 @@ import { getsBTCEnrollmentTool } from "./getsBTCEnrollment";
 import { getsBTCCurrentCycleTool } from "./getsBTCCurrentCycle";
 import { getsBTCRewardAddressTool } from "./getsBTCRewardAddress";
 import { getsBTCRewardsByCycleAddressTool } from "./getsBTCRewardsByCycleAddress";
+import { enrollsBTCIncentivesTool } from "./enrollsBTCIncentives";
 
 export interface ToolConfig<T = any> {
   /**
@@ -99,4 +100,9 @@ export const tools: Record<string, ToolConfig> = {
    * Send a transaction to another address 
    */
    send_transaction: sendTransactionTool,
+  
+  /**
+   * Enroll to sBTC incentives
+   */
+   enroll_sbtc_incentives: enrollsBTCIncentivesTool,
 };

--- a/tools/allTools.ts
+++ b/tools/allTools.ts
@@ -9,6 +9,7 @@ import { sendTransactionTool } from "./sendTransaction";
 import { getTokenInformationVelarTool } from "./getTokenInformation";
 import { getPoolInformationVelarTool } from "./getPoolInformationFromVelar";
 import { getsBTCEnrollmentTool } from "./getsBTCEnrollment";
+import { getsBTCCurrentCycleTool } from "./getsBTCCurrentCycle";
 
 export interface ToolConfig<T = any> {
   /**
@@ -78,6 +79,10 @@ export const tools: Record<string, ToolConfig> = {
    * Get the confirmation if a wallet is enrolled in sBTC incentives
    */
    get_sbtc_enrollment: getsBTCEnrollmentTool,
+  /**
+   * Get the current cycle for sBTC incentives
+   */
+   get_sbtc_currentcycle: getsBTCCurrentCycleTool,
 
   
   /**

--- a/tools/allTools.ts
+++ b/tools/allTools.ts
@@ -13,6 +13,7 @@ import { getsBTCCurrentCycleTool } from "./getsBTCCurrentCycle";
 import { getsBTCRewardAddressTool } from "./getsBTCRewardAddress";
 import { getsBTCRewardsByCycleAddressTool } from "./getsBTCRewardsByCycleAddress";
 import { enrollsBTCIncentivesTool } from "./enrollsBTCIncentives";
+import { changesBTCRewardAddressTool } from "./changesBTCRewardAddress";
 
 export interface ToolConfig<T = any> {
   /**
@@ -105,4 +106,8 @@ export const tools: Record<string, ToolConfig> = {
    * Enroll to sBTC incentives
    */
    enroll_sbtc_incentives: enrollsBTCIncentivesTool,
+  /**
+   * Change the reward address for sBTC incentives
+   */
+   change_sbtc_rewardaddress: changesBTCRewardAddressTool,
 };

--- a/tools/changesBTCRewardAddress.ts
+++ b/tools/changesBTCRewardAddress.ts
@@ -1,0 +1,39 @@
+import { changeRewardAddress } from "../src/sbtc/yieldActions";
+import type { ToolConfig } from "./allTools.js";
+
+import type { GetsBTCRewardAddressArgs } from "../interface/index.js";
+
+/**
+ * Get the sBTC Incentives enrollment of a wallet.
+ *
+ * This tool takes a single parameter, the wallet address to get the enrollment
+ * from.
+ */
+export const changesBTCRewardAddressTool: ToolConfig<GetsBTCRewardAddressArgs> = {
+  definition: {
+    type: "function",
+    function: {
+      name: "change_sbtc_rewardaddress",
+      description: "Change the sBTC reward address for this wallet",
+      parameters: {
+        type: "object",
+        properties: {
+          wallet: {
+            type: "string",
+            //pattern: "^0x[a-fA-F0-9]{40}$",
+            description: "The new wallet address to get the sBTC rewards",
+          },
+        },
+        required: [],
+      },
+    },
+  },
+  handler: async ({wallet}) => {
+    return await newAddress(wallet);
+  },
+};
+
+async function newAddress(wallet:string) {
+  const response = await changeRewardAddress(wallet);
+  return response;
+}

--- a/tools/enrollsBTCIncentives.ts
+++ b/tools/enrollsBTCIncentives.ts
@@ -1,0 +1,34 @@
+import { enrollToIncentives } from "../src/sbtc/yieldActions";
+import type { ToolConfig } from "./allTools.js";
+
+import type { GetsBTCCurrentCycleArgs } from "../interface/index.js";
+
+/**
+ * Get the sBTC Incentives enrollment of a wallet.
+ *
+ * This tool takes a single parameter, the wallet address to get the enrollment
+ * from.
+ */
+export const enrollsBTCIncentivesTool: ToolConfig<GetsBTCCurrentCycleArgs> = {
+  definition: {
+    type: "function",
+    function: {
+      name: "enroll_sbtc_incentives",
+      description: "Enroll to sBTC incentives to get rewards",
+      parameters: {
+        type: "object",
+        properties: {
+        },
+        required: [],
+      },
+    },
+  },
+  handler: async () => {
+    return await enroll();
+  },
+};
+
+async function enroll() {
+  const enrolled = await enrollToIncentives();
+  return enrolled;
+}

--- a/tools/getsBTCCurrentCycle.ts
+++ b/tools/getsBTCCurrentCycle.ts
@@ -1,0 +1,35 @@
+import { getCurrentCycle } from "../src/sbtc/yieldActions";
+import type { ToolConfig } from "./allTools.js";
+
+import type { GetsBTCCurrentCycleArgs } from "../interface/index.js";
+
+/**
+ * Get the sBTC Incentives enrollment of a wallet.
+ *
+ * This tool takes a single parameter, the wallet address to get the enrollment
+ * from.
+ */
+export const getsBTCCurrentCycleTool: ToolConfig<GetsBTCCurrentCycleArgs> = {
+  definition: {
+    type: "function",
+    function: {
+      name: "get_sbtc_currentcycle",
+      description: "Get the current cycle for sBTC rewards",
+      parameters: {
+        type: "object",
+        properties: {
+          
+        },
+        required: [],
+      },
+    },
+  },
+  handler: async () => {
+    return await currentCycle();
+  },
+};
+
+async function currentCycle() {
+  const cycle = await getCurrentCycle();
+  return cycle;
+}

--- a/tools/getsBTCEnrollment.ts
+++ b/tools/getsBTCEnrollment.ts
@@ -1,0 +1,39 @@
+import { isWalletEnrolled } from "../src/sbtc/yieldActions";
+import type { ToolConfig } from "./allTools.js";
+
+import type { GetsBTCEnrollmentArgs } from "../interface/index.js";
+
+/**
+ * Get the sBTC Incentives enrollment of a wallet.
+ *
+ * This tool takes a single parameter, the wallet address to get the enrollment
+ * from.
+ */
+export const getsBTCEnrollmentTool: ToolConfig<GetsBTCEnrollmentArgs> = {
+  definition: {
+    type: "function",
+    function: {
+      name: "get_sbtc_enrollment",
+      description: "Get the status of the enrollment in sBTC Incentives",
+      parameters: {
+        type: "object",
+        properties: {
+          wallet: {
+            type: "string",
+            //pattern: "^0x[a-fA-F0-9]{40}$",
+            description: "The wallet address to get the sBTC Incentives enrollment from",
+          },
+        },
+        required: ["wallet"],
+      },
+    },
+  },
+  handler: async ({ wallet }) => {
+    return await isEnrolled(wallet);
+  },
+};
+
+async function isEnrolled(wallet: string) {
+  const isEnrolledWallet = await isWalletEnrolled(wallet);
+  return isEnrolledWallet;
+}

--- a/tools/getsBTCRewardAddress.ts
+++ b/tools/getsBTCRewardAddress.ts
@@ -33,7 +33,7 @@ export const getsBTCRewardAddressTool: ToolConfig<GetsBTCRewardAddressArgs> = {
   },
 };
 
-async function getAddress(wallet) {
+async function getAddress(wallet:string) {
   const address = await getRewardAddress(wallet);
   return address;
 }

--- a/tools/getsBTCRewardAddress.ts
+++ b/tools/getsBTCRewardAddress.ts
@@ -1,0 +1,39 @@
+import { getRewardAddress } from "../src/sbtc/yieldActions";
+import type { ToolConfig } from "./allTools.js";
+
+import type { GetsBTCRewardAddressArgs } from "../interface/index.js";
+
+/**
+ * Get the sBTC Incentives enrollment of a wallet.
+ *
+ * This tool takes a single parameter, the wallet address to get the enrollment
+ * from.
+ */
+export const getsBTCRewardAddressTool: ToolConfig<GetsBTCRewardAddressArgs> = {
+  definition: {
+    type: "function",
+    function: {
+      name: "get_sbtc_rewardaddress",
+      description: "Get the sBTC reward address for a specific address",
+      parameters: {
+        type: "object",
+        properties: {
+          wallet: {
+            type: "string",
+            //pattern: "^0x[a-fA-F0-9]{40}$",
+            description: "The wallet address to get the sBTC reward address",
+          },
+        },
+        required: [],
+      },
+    },
+  },
+  handler: async ({wallet}) => {
+    return await getAddress(wallet);
+  },
+};
+
+async function getAddress(wallet) {
+  const address = await getRewardAddress(wallet);
+  return address;
+}

--- a/tools/getsBTCRewardsByCycleAddress.ts
+++ b/tools/getsBTCRewardsByCycleAddress.ts
@@ -1,0 +1,42 @@
+import { getRewardsByCycleAddress } from "../src/sbtc/yieldActions";
+import type { ToolConfig } from "./allTools.js";
+
+import type { GetsBTCRewardsByCycleAddressArgs } from "../interface/index.js";
+
+/**
+ * Get the sBTC Incentives rewards of a wallet.
+ *
+ */
+export const getsBTCRewardsByCycleAddressTool: ToolConfig<GetsBTCRewardsByCycleAddressArgs> = {
+  definition: {
+    type: "function",
+    function: {
+      name: "get_sbtc_rewardsbycycleaddress",
+      description: "Get the sBTC rewards for a specific cycle and address",
+      parameters: {
+        type: "object",
+        properties: {
+          cycle: {
+            type: "number",
+            //pattern: "^0x[a-fA-F0-9]{40}$",
+            description: "The cycle to get the rewards",
+          },
+          wallet: {
+            type: "string",
+            //pattern: "^0x[a-fA-F0-9]{40}$",
+            description: "The wallet address to get the sBTC rewards",
+          },
+        },
+        required: ["cycle","wallet"],
+      },
+    },
+  },
+  handler: async ({cycle, wallet}) => {
+    return await getRewards(cycle, wallet);
+  },
+};
+
+async function getRewards(cycle:number, wallet:string) {
+  const rewards = await getRewardsByCycleAddress(cycle, wallet);
+  return rewards;
+}

--- a/tools/optOutBTCIncentives.ts
+++ b/tools/optOutBTCIncentives.ts
@@ -1,0 +1,34 @@
+import { optoutToIncentives } from "../src/sbtc/yieldActions";
+import type { ToolConfig } from "./allTools.js";
+
+import type { GetsBTCCurrentCycleArgs } from "../interface/index.js";
+
+/**
+ * Get the sBTC Incentives enrollment of a wallet.
+ *
+ * This tool takes a single parameter, the wallet address to get the enrollment
+ * from.
+ */
+export const optoutsBTCIncentivesTool: ToolConfig<GetsBTCCurrentCycleArgs> = {
+  definition: {
+    type: "function",
+    function: {
+      name: "optout_sbtc_incentives",
+      description: "Unenroll/opt-out for sBTC incentives",
+      parameters: {
+        type: "object",
+        properties: {
+        },
+        required: [],
+      },
+    },
+  },
+  handler: async () => {
+    return await unenroll();
+  },
+};
+
+async function unenroll() {
+  const unenrolled = await optoutToIncentives();
+  return unenrolled;
+}


### PR DESCRIPTION
Add [sBTC Incentives](https://bitcoinismore.org/) functions (from Clarity Smart Contract) to verify the incentives, register, and unregister.

New functions:

- Get the status of the enrollment in [sBTC Incentives](https://bitcoinismore.org/) for a wallet (using **get_sbtc_enrollment**)
- Get the status of the enrollment in sBTC Incentives for a wallet (if no address is specified, use the current wallet) (using **get_sbtc_enrollment**)
- Get the current cycle for sBTC rewards (using **get_sbtc_currentcycle**)
- Get the current/last sBTC reward address for a specific address (using **get_sbtc_rewardaddress**)
- Get the sBTC rewards for a specific cycle and address (using **get_sbtc_rewardsbycycleaddress**)
- Enroll for sBTC incentives (using the agent wallet) and get rewards (using **enroll_sbtc_incentives**)
- Change the address to receive the sBTC rewards (using **change_sbtc_rewardaddress**)
- Unenroll/opt-out for sBTC incentives (using **optout_sbtc_incentives**)